### PR TITLE
Add an useAllDocs hook

### DIFF
--- a/api.js
+++ b/api.js
@@ -6,7 +6,8 @@ module.exports = module => {
       /\\/g,
       '/'
     ) || '.';
-  module.exports = `import apiFind from '${root}/api/Find';
+  module.exports = `import apiAllDocs from '${root}/api/AllDocs';
+import apiFind from '${root}/api/Find';
 import apiGet from '${root}/api/Get';
 import apiUseFind from '${root}/api/useFind';
 import apiUseGet from '${root}/api/useGet';
@@ -20,6 +21,7 @@ export useDB from '${root}/useDB';
 export const useFind = apiUseFind(useListen);
 export const useGet = apiUseGet(useListen);
 export const useAllDocs = apiUseAllDocs(useListen);
+export const AllDocs = apiAllDocs(useAllDocs);
 export const Find = apiFind(useFind);
 export const Get = apiGet(useGet);`;
 };

--- a/api.js
+++ b/api.js
@@ -10,6 +10,7 @@ module.exports = module => {
 import apiGet from '${root}/api/Get';
 import apiUseFind from '${root}/api/useFind';
 import apiUseGet from '${root}/api/useGet';
+import apiUseAllDocs from '${root}/api/useAllDocs';
 import useListen from './useListen';
 
 export PouchDB from '${root}/PouchDB';
@@ -18,6 +19,7 @@ export * as DBContext from '${root}/DBContext';
 export useDB from '${root}/useDB';
 export const useFind = apiUseFind(useListen);
 export const useGet = apiUseGet(useListen);
+export const useAllDocs = apiUseAllDocs(useListen);
 export const Find = apiFind(useFind);
 export const Get = apiGet(useGet);`;
 };

--- a/src/api/AllDocs.js
+++ b/src/api/AllDocs.js
@@ -1,0 +1,6 @@
+import renderProps from '../renderProps';
+
+export default renderProps(doc => ({ doc }), {
+  callee: '<AllDocs>',
+  example: '<AllDocs db={name|options} ... />'
+});

--- a/src/api/useAllDocs.js
+++ b/src/api/useAllDocs.js
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import stringify from 'fast-json-stable-stringify';
+import reverseArgs from '../utils/reverseArgs';
+import changes from '../changes';
+import useDB from '../useDB';
+
+const UINT8ARRAY = 'u8a';
+
+const changesOptions = {
+  live: true,
+  include_docs: true,
+  since: 'now',
+  // Documents are kept in memory. 'complete' event can return an empty array.
+  return_docs: false
+};
+
+export default useListen =>
+  reverseArgs(function useAllDocs(options, db) {
+    db = useDB(db, {
+      callee: 'useAllDocs',
+      example: 'useAllDocs(db, options)'
+    });
+
+    const {
+      startkey,
+      endkey,
+      descending,
+      attachments,
+      limit,
+      skip,
+      ...otherOptions
+    } = options;
+    const binary = attachments === UINT8ARRAY;
+
+    const optionsWithAttachmentAndBinaryOption = useMemo(
+      () => ({
+        binary,
+        startkey,
+        endkey,
+        descending,
+        limit,
+        skip,
+        ...otherOptions,
+        attachments: !!attachments
+      }),
+      [
+        binary,
+        startkey,
+        endkey,
+        descending,
+        limit,
+        skip,
+        stringify(otherOptions),
+        !!attachments
+      ]
+    );
+    const keysMode = options.key != null;
+    const keyMode = options.keys != null;
+
+    return useListen(db, options, async setValue => {
+      const { rows } = await db.allDocs(optionsWithAttachmentAndBinaryOption);
+      const update = () => setValue([...rows]);
+      update();
+
+      return db::changes(changesOptions, async ({ deleted, id, doc }) => {
+        const index = rows.findIndex(row => row.id === id);
+        const found = index !== -1;
+
+        // Document was deleted
+        if (deleted) {
+          if (found) {
+            // remove row
+            rows.splice(index, 1);
+
+            if (rows.length + 1 === limit && !keysMode && !keyMode) {
+              const lastId = rows[rows.length - 1].id;
+              const replacementRows = await db.allDocs({
+                ...optionsWithAttachmentAndBinaryOption,
+                startkey: lastId,
+                skip: 1,
+                limit: 1
+              });
+              rows.push(...replacementRows.rows);
+            } else if (keysMode && !keyMode) {
+              const replacementRows = await db.allDocs({
+                ...optionsWithAttachmentAndBinaryOption,
+                keys: [id]
+              });
+              rows.splice(index, 0, ...replacementRows.rows);
+            }
+
+            update();
+          }
+          return;
+        }
+
+        if (found) {
+          rows[index] = {
+            id,
+            key: id,
+            value: {
+              rev: doc._rev
+            },
+            doc: optionsWithAttachmentAndBinaryOption.include_docs
+              ? doc
+              : undefined
+          };
+          update();
+        }
+      });
+    });
+  });

--- a/src/api/useAllDocs.js
+++ b/src/api/useAllDocs.js
@@ -1,18 +1,59 @@
 import { useMemo } from 'react';
 import stringify from 'fast-json-stable-stringify';
 import reverseArgs from '../utils/reverseArgs';
+import attachmentsAsUint8Arrays from '../attachmentsAsUint8Arrays';
 import changes from '../changes';
 import useDB from '../useDB';
 
 const UINT8ARRAY = 'u8a';
 
-const changesOptions = {
-  live: true,
-  include_docs: true,
-  since: 'now',
-  // Documents are kept in memory. 'complete' event can return an empty array.
-  return_docs: false
-};
+/**
+ * Converts all attachments of a document into Uint8Arrays, if the binary option is set.
+ * @param {boolean} binary Should the attachments be converted into an Uint8Array.
+ * @param {object} doc The document.
+ */
+async function formatDocAttachments(binary, doc) {
+  return binary && doc && !doc._deleted && '_attachments' in doc
+    ? {
+        ...doc,
+        _attachments: await attachmentsAsUint8Arrays(doc._attachments)
+      }
+    : doc;
+}
+
+/**
+ * Transforms a change object into a row object.
+ * @param {boolean} includeDocs Should documents be included in the allDocs result.
+ * @param {boolean} binary Should the attachments be converted into an Uint8Array.
+ * @param {object} change PouchDB-Change-Object.
+ */
+async function transformToRow(includeDocs, binary, change) {
+  return {
+    id: change.id,
+    key: change.id,
+    value: change.changes[0],
+    doc:
+      includeDocs && change.doc
+        ? await formatDocAttachments(binary, change.doc)
+        : undefined
+  };
+}
+
+/**
+ * Converts all attachments into Uint8Arrays.
+ * The rows will be updated in place, while the documents are copied.
+ * @param {Object[]} rows Rows that should be updated IN PLACE.
+ */
+function formatRowsAttachments(binary, rows) {
+  // The mapped value is the Promise. The rows will be updated in place!
+  const converting = rows.map(async row => {
+    if (row.doc && row.doc._attachments) {
+      row.doc = await formatDocAttachments(binary, row.doc);
+    }
+  });
+
+  return Promise.all(converting);
+}
 
 export default useListen =>
   reverseArgs(function useAllDocs(options, db) {
@@ -54,24 +95,67 @@ export default useListen =>
         !!attachments
       ]
     );
-    const keysMode = options.key != null;
-    const keyMode = options.keys != null;
+    const keysMode = options.keys != null;
+    const keyMode = options.key != null;
+
+    const changesOptions = useMemo(() => {
+      const changesOptions = {
+        live: true,
+        include_docs: optionsWithAttachmentAndBinaryOption.include_docs,
+        since: 'now',
+        // Documents are kept in memory. 'complete' event can return an empty array.
+        return_docs: false
+      };
+      // add keys/key to only subscribe to those.
+      if (keyMode) {
+        changesOptions.doc_ids = [optionsWithAttachmentAndBinaryOption.key];
+      } else if (keysMode) {
+        changesOptions.doc_ids = optionsWithAttachmentAndBinaryOption.keys;
+      }
+      return changesOptions;
+    }, [optionsWithAttachmentAndBinaryOption, keysMode, keyMode]);
 
     return useListen(db, options, async setValue => {
       const { rows } = await db.allDocs(optionsWithAttachmentAndBinaryOption);
+      if (binary) {
+        await formatRowsAttachments(binary, rows);
+      }
       const update = () => setValue([...rows]);
       update();
+      const toRow = transformToRow.bind(null, options.include_docs, binary);
 
-      return db::changes(changesOptions, async ({ deleted, id, doc }) => {
+      return db::changes(changesOptions, async change => {
+        const { id } = change;
+
+        // guards that check if the document's id is between startkey and endkey.
+        // But only if they exist.
+        if (
+          startkey != null &&
+          ((descending && id > startkey) || (!descending && id < startkey))
+        ) {
+          return;
+        }
+        if (
+          endkey != null &&
+          ((descending && id < endkey) ||
+            (!descending && id > endkey) ||
+            // if inclusive_end is omitted, it defaults to true
+            (options.inclusive_end === false && endkey === id))
+        ) {
+          return;
+        }
+
         const index = rows.findIndex(row => row.id === id);
         const found = index !== -1;
 
         // Document was deleted
-        if (deleted) {
+        if (change.deleted) {
           if (found) {
             // remove row
             rows.splice(index, 1);
 
+            // ranges mode (with startkey and endkey)
+            // If it was on the limit load the next row/document.
             if (rows.length + 1 === limit && !keysMode && !keyMode) {
               const lastId = rows[rows.length - 1].id;
               const replacementRows = await db.allDocs({
@@ -80,31 +164,48 @@ export default useListen =>
                 skip: 1,
                 limit: 1
               });
+              if (binary) {
+                await formatRowsAttachments(binary, replacementRows.rows);
+              }
               rows.push(...replacementRows.rows);
             } else if (keysMode && !keyMode) {
               const replacementRows = await db.allDocs({
                 ...optionsWithAttachmentAndBinaryOption,
                 keys: [id]
               });
+              if (binary) {
+                await formatRowsAttachments(binary, replacementRows.rows);
+              }
               rows.splice(index, 0, ...replacementRows.rows);
             }
 
             update();
           }
-          return;
-        }
+        } else if (found) {
+          rows[index] = await toRow(change);
+          update();
+        } else {
+          // add the new row
+          let insertIndex = rows.findIndex(
+            descending
+              ? row => row.id < id // if descending find the first row with a smaller id
+              : row => row.id > id // else find the first row with a bigger id
+          );
+          if (insertIndex === -1) {
+            // If no index was found, then push it to the end
+            if (limit != null && rows.length === limit) {
+              // But not if the limit is already exceeded
+              return;
+            }
+            insertIndex = rows.length;
+          }
 
-        if (found) {
-          rows[index] = {
-            id,
-            key: id,
-            value: {
-              rev: doc._rev
-            },
-            doc: optionsWithAttachmentAndBinaryOption.include_docs
-              ? doc
-              : undefined
-          };
+          rows.splice(insertIndex, 0, await toRow(change));
+
+          if (limit != null && rows.length > limit) {
+            // remove the last row if the limit was exceeded.
+            rows.pop();
+          }
           update();
         }
       });

--- a/src/api/useAllDocs.js
+++ b/src/api/useAllDocs.js
@@ -75,6 +75,8 @@ export default useListen =>
 
     const optionsWithAttachmentAndBinaryOption = useMemo(
       () => ({
+        // binary option will be overwritten by otherOptions.binary
+        // so that a Blob can be used.
         binary,
         startkey,
         endkey,
@@ -125,7 +127,7 @@ export default useListen =>
       const toRow = transformToRow.bind(null, options.include_docs, binary);
 
       return db::changes(changesOptions, async change => {
-        const { id } = change;
+        const { id, deleted } = change;
 
         // guards that check if the document's id is between startkey and endkey.
         // But only if they exist.
@@ -149,7 +151,7 @@ export default useListen =>
         const found = index !== -1;
 
         // Document was deleted
-        if (change.deleted) {
+        if (deleted) {
           if (found) {
             // remove row
             rows.splice(index, 1);

--- a/testapp/src/Tests/AllDocuments.js
+++ b/testapp/src/Tests/AllDocuments.js
@@ -1,0 +1,16 @@
+import { useTestRender, SynchronousAndConcurrentAPIs } from 'Test';
+
+export default function AllDocuments({ id, ...otherProps }) {
+  return (
+    <SynchronousAndConcurrentAPIs {...otherProps}>
+      {api => <Test {...{ api, id }} />}
+    </SynchronousAndConcurrentAPIs>
+  );
+}
+
+function Test({ api: { useAllDocs }, ...otherProps }) {
+  const docs = useAllDocs(otherProps);
+  return useTestRender(
+    docs ? (docs.length ? docs[0].value : 'empty array') : docs
+  );
+}

--- a/testapp/src/Tests/AllDocuments.js
+++ b/testapp/src/Tests/AllDocuments.js
@@ -1,9 +1,9 @@
 import { useTestRender, SynchronousAndConcurrentAPIs } from 'Test';
 
-export default function AllDocuments({ id, ...otherProps }) {
+export default function AllDocuments({ keys, ...otherProps }) {
   return (
     <SynchronousAndConcurrentAPIs {...otherProps}>
-      {api => <Test {...{ api, id }} />}
+      {api => <Test {...{ api, keys, include_docs: true }} />}
     </SynchronousAndConcurrentAPIs>
   );
 }
@@ -11,6 +11,6 @@ export default function AllDocuments({ id, ...otherProps }) {
 function Test({ api: { useAllDocs }, ...otherProps }) {
   const docs = useAllDocs(otherProps);
   return useTestRender(
-    docs ? (docs.length ? docs[0].value : 'empty array') : docs
+    docs ? (docs.length ? docs[0].doc.value : 'empty array') : docs
   );
 }

--- a/testapp/src/Tests/AllDocuments.js
+++ b/testapp/src/Tests/AllDocuments.js
@@ -1,15 +1,15 @@
 import { useTestRender, SynchronousAndConcurrentAPIs } from 'Test';
 
-export default function AllDocuments({ keys, ...otherProps }) {
+export default function AllDocuments({ singleKey, keys, ...otherProps }) {
   return (
     <SynchronousAndConcurrentAPIs {...otherProps}>
-      {api => <Test {...{ api, keys, include_docs: true }} />}
+      {api => <Test {...{ api, singleKey, keys, include_docs: true }} />}
     </SynchronousAndConcurrentAPIs>
   );
 }
 
-function Test({ api: { useAllDocs }, ...otherProps }) {
-  const docs = useAllDocs(otherProps);
+function Test({ api: { useAllDocs }, singleKey, ...otherProps }) {
+  const docs = useAllDocs({ key: singleKey, ...otherProps });
   return useTestRender(
     docs
       ? docs.length

--- a/testapp/src/Tests/AllDocuments.js
+++ b/testapp/src/Tests/AllDocuments.js
@@ -11,6 +11,12 @@ export default function AllDocuments({ keys, ...otherProps }) {
 function Test({ api: { useAllDocs }, ...otherProps }) {
   const docs = useAllDocs(otherProps);
   return useTestRender(
-    docs ? (docs.length ? docs[0].doc.value : 'empty array') : docs
+    docs
+      ? docs.length
+        ? docs[0].doc
+          ? docs[0].doc.value
+          : 'deleted'
+        : 'empty array'
+      : docs
   );
 }

--- a/testapp/src/Tests/index.js
+++ b/testapp/src/Tests/index.js
@@ -50,9 +50,9 @@ export default function Tests() {
               'loading',
               'created',
               'update',
-              'empty array'
+              'deleted'
             ],
-            synchronous: ['loading', 'created', 'update', 'empty array']
+            synchronous: ['loading', 'created', 'update', 'deleted']
           }}
         />
       )}

--- a/testapp/src/Tests/index.js
+++ b/testapp/src/Tests/index.js
@@ -43,7 +43,7 @@ export default function Tests() {
       {config.allDocs && config.existing && (
         <AllDocuments
           keys={['a']}
-          message="All existing documents"
+          message="All existing documents with keys"
           expected={{
             concurrent: [
               'undefined',
@@ -53,6 +53,62 @@ export default function Tests() {
               'deleted'
             ],
             synchronous: ['loading', 'created', 'update', 'deleted']
+          }}
+        />
+      )}
+      {config.allDocs && config.missing && (
+        <AllDocuments
+          keys={['b']}
+          message="All documents with keys and missing docs"
+          expected={{
+            concurrent: [
+              'undefined',
+              'loading',
+              'deleted',
+              'deleted',
+              'deleted',
+              'deleted'
+            ],
+            synchronous: ['loading', 'deleted', 'deleted', 'deleted', 'deleted']
+          }}
+        />
+      )}
+      {config.allDocs && config.existing && (
+        <AllDocuments
+          singleKey="a"
+          message="All documents with a key"
+          expected={{
+            concurrent: [
+              'undefined',
+              'loading',
+              'created',
+              'update',
+              'empty array'
+            ],
+            synchronous: ['loading', 'created', 'update', 'empty array']
+          }}
+        />
+      )}
+      {config.allDocs && config.missing && (
+        <AllDocuments
+          singleKey="b"
+          message="All documents with a key of a missing doc"
+          expected={{
+            concurrent: [
+              'undefined',
+              'loading',
+              'empty array',
+              'created',
+              'update',
+              'empty array'
+            ],
+            synchronous: [
+              'loading',
+              'empty array',
+              'created',
+              'update',
+              'empty array'
+            ]
           }}
         />
       )}

--- a/testapp/src/Tests/index.js
+++ b/testapp/src/Tests/index.js
@@ -1,6 +1,7 @@
 import { config } from 'Test';
 import FindDocument from './FindDocument';
 import GetDocument from './GetDocument';
+import AllDocuments from './AllDocuments';
 import DontSwallowErrors from './DontSwallowErrors';
 
 export default function Tests() {
@@ -36,6 +37,22 @@ export default function Tests() {
               'deleted'
             ],
             synchronous: ['loading', 'null', 'created', 'update', 'deleted']
+          }}
+        />
+      )}
+      {config.allDocs && config.existing && (
+        <AllDocuments
+          id="a"
+          message="All existing documents"
+          expected={{
+            concurrent: [
+              'undefined',
+              'loading',
+              'created',
+              'update',
+              'empty array'
+            ],
+            synchronous: ['loading', 'created', 'update', 'empty array']
           }}
         />
       )}

--- a/testapp/src/Tests/index.js
+++ b/testapp/src/Tests/index.js
@@ -42,7 +42,7 @@ export default function Tests() {
       )}
       {config.allDocs && config.existing && (
         <AllDocuments
-          id="a"
+          keys={['a']}
           message="All existing documents"
           expected={{
             concurrent: [

--- a/testapp/src/shared/Test/config.json
+++ b/testapp/src/shared/Test/config.json
@@ -1,5 +1,6 @@
 {
   "get": true,
+  "allDocs": true,
   "find": true,
   "existing": true,
   "missing": true,


### PR DESCRIPTION
This pull request adds an useAllDocs hook.

It uses `db.allDocs()`. Its use-cases are:
- Load and subscribe to multiple documents (using the `keys`-option)
- Load and subscribe to a range of documents, sorted by their `id`'s (using the `startkey` and `endkey` options)